### PR TITLE
Fix/cred sourceuri error

### DIFF
--- a/lib/cleaners.py
+++ b/lib/cleaners.py
@@ -25,6 +25,10 @@ def normalize_uri(uri, issuer_id=None):
             domain = parts[0].lower()
             path = "/" + parts[1] if len(parts) > 1 else ""
 
+    if parsed_url.query:
+        path = f"{path}?{parsed_url.query}"
+
+
     print(f"Domain: {domain}  Path:{path}")
 
     # Add the http or https prefix if necessary


### PR DESCRIPTION
when creating a claim from a cred the source name is always "Error 400 (Bad Request)!!1" and and source uri didn't have the query params
![image](https://github.com/user-attachments/assets/4c4a086f-1211-446a-a5c4-4b37f24dbc0f)

not it is working

![image](https://github.com/user-attachments/assets/e1f34270-c498-4136-8558-8ca000076ce4)
